### PR TITLE
Added data schema to render base64 images

### DIFF
--- a/packages/bundle/src/renderMarkdown.js
+++ b/packages/bundle/src/renderMarkdown.js
@@ -8,8 +8,8 @@ const SANITIZE_HTML_OPTIONS = {
   allowedAttributes: {
     a: ['href', 'name', 'target', 'title'],
     img: ['alt', 'src']
-  },
-  allowedSchemes: ['http', 'https', 'ftp', 'mailto', 'sip'],
+  },  
+  allowedSchemes: ['data','http', 'https', 'ftp', 'mailto', 'sip'],
   allowedTags: [
     'a',
     'b',


### PR DESCRIPTION
Fixes 
`# 1896`
`# 1401`

## Changelog Entry	

- Add data schema to render base64 images

 ## Specific Changes	

Added `data` scheme to the default allowedSchemes in Web Chat's [sanitize html options](https://github.com/microsoft/BotFramework-WebChat/blob/master/packages/bundle/src/renderMarkdown.js).

 ## Testing
We test the fix using the playground application.	
![image](https://user-images.githubusercontent.com/37461749/59198931-321c7c80-8b6b-11e9-8f39-169588c1db04.png)

We also tested these changes with the botframework-emulator.
![image](https://user-images.githubusercontent.com/37461749/59199037-655f0b80-8b6b-11e9-9128-8ed97b8ca9dc.png)
